### PR TITLE
[calabash] add calabash hook's file

### DIFF
--- a/qa_testing/calabash/README.md
+++ b/qa_testing/calabash/README.md
@@ -78,6 +78,22 @@ Execution commands:
 
 ![Gemfile](./static/gemfile.png "Gemfile")
 
+- Hook's files: contains the hooks for each platform.
+
+This files are located inside *impl/support* directory, separated by one folder for each platform: *android* and *ios*.
+
+Inside *impl/support/android* we can find the next files:
+
+- app_installation_hooks.rb: contains the scenario and *AfterConfiguration* hooks.
+- app_file_cycle_hooks.rb: contains the *Before* and *After* global hooks.
+- hook.rb: contains the user custom hooks.
+
+Inside *impl/support/ios* we can find the next files:
+
+- 01_launch.rb: contains the default preconfigurated hooks.
+- hooks.rb: contains the user custom hooks.
+
+You can edit this files to accomplish your needs. You can read more about hooks [here](https://github.com/cucumber/cucumber/wiki/Hooks)
 
 ### Background
 


### PR DESCRIPTION
Agregated to the calabash's README file, information about hooks files.